### PR TITLE
adding a pants_color field on install, removing it on uninstall and u…

### DIFF
--- a/config/install/field.field.user.user.pants_color.yml
+++ b/config/install/field.field.user.user.pants_color.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.pants_color
+  module:
+    - options
+    - user
+id: user.user.pants_color
+field_name: pants_color
+entity_type: user
+bundle: user
+label: 'Pants Color'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/install/field.storage.user.pants_color.yml
+++ b/config/install/field.storage.user.pants_color.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - user
+id: user.pants_color
+field_name: pants_color
+entity_type: user
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: blue
+      label: blue
+    -
+      value: red
+      label: red
+    -
+      value: green
+      label: green
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/pants.install
+++ b/pants.install
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Implements hook_uninstall().
+ */
+function pants_uninstall() {
+  $field = \Drupal::entityTypeManager()->getStorage('field_config')->load('user.user.pants_color');
+  $field->delete();
+  //$field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config')->load('user.pants_color');
+  //$field_storage->delete();
+}

--- a/src/Plugin/Block/PantsColor.php
+++ b/src/Plugin/Block/PantsColor.php
@@ -16,7 +16,10 @@ use Drupal\Core\Link;
  *
  * @Block(
  *   id = "pants_color",
- *   admin_label = @Translation("Current user's pants color")
+ *   admin_label = @Translation("Current user's pants color"),
+ *   context = {
+ *     "user" = @ContextDefinition("entity:user", label = @Translation("Current User"))
+ *   }
  * )
  */
 class PantsColor extends BlockBase {
@@ -25,7 +28,7 @@ class PantsColor extends BlockBase {
    * {@inheritdoc}
    */
   public function build() {
-    $user = \Drupal::currentUser();
+    $user = $this->getContextValue('user');
 
     $config = \Drupal::config('pants.settings');
     $pants_color = isset($user->pants_color->value) ? $user->pants_color->value : $config->get('default_color');


### PR DESCRIPTION
…pdating the PantsColor block to accept a user context so that it caches properly.

The block update on this is especially important since it fixes caching issues with the user specific pants block by properly leveraging the plugin context system.